### PR TITLE
Fixes XML canonicalization and digest calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "thumbprint": "0.0.1",
-    "xml-crypto": "0.8.4",
+    "xml-crypto": "github:nicosabena/xml-crypto#c14n-line-endings",
     "xml-encryption": "^0.10.0",
     "xmldom": "0.1.22",
     "xpath": "0.0.23"

--- a/src/src/elements/BaseElement.ts
+++ b/src/src/elements/BaseElement.ts
@@ -38,15 +38,13 @@ export default class BaseElement{
     this._transforms = settings.transforms;
     this._signaturePrefix = settings.signaturePrefix;
     this._xml = xml;
-    this.idAttribute = 'ID';
   }
 
   signXml(key) {
     utils.removeHeaders(this._publicKey);
 
     var sig = new SignedXml(null, {
-      signatureAlgorithm: algorithms.signature[this._sig_alg],
-      idAttribute: this.idAttribute
+      signatureAlgorithm: algorithms.signature[this._sig_alg]
     });
 
     sig.addReference(this.reference, this._transforms, algorithms.digest[this._digest_alg]);
@@ -78,7 +76,7 @@ export default class BaseElement{
         return [];
       }
 
-      var sig = new xmlCrypto.SignedXml(null, { idAttribute: this.idAttribute });
+      var sig = new xmlCrypto.SignedXml();
       sig.keyInfoProvider = {
         getKeyInfo: function() {
           return '<X509Data></X509Data>';


### PR DESCRIPTION
`xml-crypto@0.8.4` has some errors in the canonicalization algorithm (see https://github.com/yaronn/xml-crypto/issues/195). This was breaking the digest calculation for some valid SAML responses.
I updated the reference to a fork of `xml-crypto` that fixes the problem.
Removed the `idAttribute` from the options when constructing the `SignedXml` option as `ID` is already in `xml-crypto` as an available id, and adding it was causing duplicate problems.

https://github.com/yaronn/xml-crypto/blob/6c30b52e656233f11b201c8593ef2f43496c2dd0/lib/signed-xml.js#L304-L305
