### PR TITLE
Pick up xml-crypto 1.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "thumbprint": "0.0.1",
-    "xml-crypto": "github:nicosabena/xml-crypto#c14n-line-endings",
+    "xml-crypto": "^1.4.1",
     "xml-encryption": "^0.10.0",
     "xmldom": "0.1.22",
     "xpath": "0.0.23"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "thumbprint": "0.0.1",
-    "xml-crypto": "^1.4.1",
+    "xml-crypto": "^1.5.1",
     "xml-encryption": "^0.10.0",
     "xmldom": "0.1.22",
     "xpath": "0.0.23"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "dependencies": {
     "thumbprint": "0.0.1",
-    "xml-crypto": "^1.5.1",
+    "xml-crypto": "^1.5.3",
     "xml-encryption": "^0.10.0",
     "xmldom": "0.1.22",
     "xpath": "0.0.23"


### PR DESCRIPTION
This change incorporates yaronn/xml-crypto#196 , @nicosabena's fix for 
whitespace normalization. While the fix is already in this release, it's done through
a fork that @nicosabena maintained until xml-crypto finally patched the official release