### PR TITLE
Version 0.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,12 @@ This extension contributes the following settings:
 - `samlExtension.sig_alg`: Configures signature algorithm used when signing an element. Default value `rsa-sha256`
 - `samlExtension.digest_alg`: Configure digest algorithm used when signing an element. Default value `sha256` 
 - `samlExtension.transforms`: Configure transforms used when signing an element. Default value `["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#" ]`
-- `samlExtension.publicKey`: Configure public key used when verifying the signature an element. Default value empty
+- `samlExtension.publicKey`: Configure public key certificate used when signing or verifying the signature an element. Default value empty. If set, it should be in PEM format, like this:
+```
+"-----BEGIN CERTIFICATE-----\n[64 base-64 chars]\n[64 base-64 chars][...]-----END CERTIFICATE-----"
+```
 - `samlExtension.signaturePrefix`: Configures the Signature Namespace prefix used when signing an Element. Default value `ds`
+- `samlExtension.privateKey`: Configures a default private key used when signing an element. Default value empty. If set, it should be in PEM format, like this:
+```
+"-----BEGIN RSA PRIVATE KEY-----\n[64 base-64 chars]\n[64 base-64 chars][...]-----END RSA PRIVATE KEY-----"
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This extension adds some helper functionality to work with SAML elements
 * SAML: Encode and deflate
 * SAML: Decode
 * SAML: Decode and Inflate
+* SAML: Decrypt
+* SAML: Format certificate as PEM
+* SAML: Calculate a certificate thumbprint
 
 ## Using
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saml-extension",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saml-extension",
   "displayName": "SAML Extension",
   "description": "SAML Extension",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "publisher": "mcastany",
   "engines": {
     "vscode": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,14 @@
             "string"
           ],
           "default": "",
-          "description": "Configure Public Key"
+          "description": "Configure default public key certificate for signing and verification, in PEM format or raw base64 data"
+        },
+        "samlExtension.privateKey": {
+          "type": [
+            "string"
+          ],
+          "default": "",
+          "description": "Configure default private key for signing, in PEM format"
         },
         "samlExtension.signaturePrefix": {
           "type": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "onCommand:samlExtension.decodeAndInflate",
     "onCommand:samlExtension.decodeUrl",
     "onCommand:samlExtension.encodeUrl",
+    "onCommand:samlExtension.getThumbprint",
+    "onCommand:samlExtension.formatCertificate",
     "onCommand:samlExtension.decrypt"
   ],
   "main": "./out/src/extension",
@@ -58,6 +60,14 @@
       {
         "command": "samlExtension.encodeUrl",
         "title": "SAML: URL Encode"
+      },
+      {
+        "command": "samlExtension.getThumbprint",
+        "title": "SAML: Calculate a Certificate Thumbprint"
+      },
+      {
+        "command": "samlExtension.formatCertificate",
+        "title": "SAML: Format Certificate as PEM"
       },
       {
         "command": "samlExtension.decrypt",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,8 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('samlExtension.encodeUrl', SAMLExtension.urlEncode));
     context.subscriptions.push(vscode.commands.registerCommand('samlExtension.decodeUrl', SAMLExtension.urlDecode));
     context.subscriptions.push(vscode.commands.registerCommand('samlExtension.decrypt', SAMLExtension.decrypt));
+    context.subscriptions.push(vscode.commands.registerCommand('samlExtension.formatCertificate', SAMLExtension.formatCertificate));
+    context.subscriptions.push(vscode.commands.registerCommand('samlExtension.getThumbprint', SAMLExtension.getThumbprint));
 }
 
 // this method is called when your extension is deactivated

--- a/src/src/elements/BaseElement.ts
+++ b/src/src/elements/BaseElement.ts
@@ -72,7 +72,8 @@ export default class BaseElement{
       prefix: this._signaturePrefix || ''
     });
 
-    return sig.getSignedXml();
+    // re-encode any previously encoded carriage return 
+    return utils.encodeCarriageReturns(sig.getSignedXml());
   }
 
   validateSignature(public_key?: string) {
@@ -136,7 +137,7 @@ export default class BaseElement{
       return xmlenc.decrypt(encryptedData, { key: key,}, (err, val) => {
         if (err) return cb(err);
 
-        cb(null, this._xml.toString().replace(encryptedToken.toString(), val));
+        cb(null, utils.encodeCarriageReturns(this._xml.toString().replace(encryptedToken.toString(), val)));
       });
     }
   }

--- a/src/src/elements/BaseElement.ts
+++ b/src/src/elements/BaseElement.ts
@@ -45,23 +45,22 @@ export default class BaseElement{
     this._xml = xml;
   }
 
-  signXml(key) {
-    utils.removeHeaders(this._publicKey);
-
+  signXml(privateKey, certificate) {
     var sig = new SignedXml(null, {
       signatureAlgorithm: algorithms.signature[this._sig_alg],
       idAttribute: additionalIdAttribute
     });
 
     sig.addReference(this.reference, this._transforms, algorithms.digest[this._digest_alg]);
-    sig.signingKey = key;
+    sig.signingKey = utils.formatCert(privateKey);
+
     sig.keyInfoProvider = {
       getKeyInfo: (key, prefix) => {
         prefix = prefix ? prefix + ':' : prefix;
         
-        if (!this._publicKey) return `<${prefix}X509Data></${prefix}X509Data>`;
+        if (!certificate) return `<${prefix}X509Data></${prefix}X509Data>`;
 
-        return `<${prefix}X509Data><${prefix}X509Certificate>${this._publicKey}</${prefix}X509Certificate></${prefix}X509Data>"`;
+        return `<${prefix}X509Data><${prefix}X509Certificate>${utils.removeHeaders(certificate)}</${prefix}X509Certificate></${prefix}X509Data>"`;
       }
     };
     sig.computeSignature(this._xml.toString(), {

--- a/src/src/elements/Response.ts
+++ b/src/src/elements/Response.ts
@@ -20,13 +20,13 @@ export default class Response extends BaseElement {
       this.Assertion = new Assertion(xml);
   } 
 
-  signXml(key){
+  signXml(key, cert){
     let xml;
 
     if (this.signedResponse){
-      return super.signXml(key);
+      return super.signXml(key, cert);
     } else {
-      return this.Assertion.signXml(key);
+      return this.Assertion.signXml(key, cert);
     }
   }
 

--- a/src/src/index.ts
+++ b/src/src/index.ts
@@ -12,29 +12,54 @@ const zlib   = require('zlib');
 const ELEMENT_NODE = 1;
 
 let suggestedPrivateKey;
+let suggestedCertificate;
 
-export function sign(){
-  var text = getText();
+export async function sign(){
+  const settings = vscode.workspace.getConfiguration("samlExtension");
+  const text = getText();
   if (!text){
     return;
   }
 
-  vscode.window.showInputBox({prompt: 'Private Key? used to sign the request (it will be kept in memory)', value: suggestedPrivateKey })
-    .then(val => {
-      if (!val){ 
-        return vscode.window.showErrorMessage('Certificate not provided');
-      }
-      
-      suggestedPrivateKey = val;
-      val = utils.formatCert(val || '');
+  const samlElement = createSAMLElement(text);          
+  if (!(samlElement instanceof BaseElement)){
+    return vscode.window.showErrorMessage('XML is not a valid SAML Element');    
+  }
 
-      try{
-        var samlElement = createSAMLElement(text);          
-        setText(samlElement.signXml(val));
-      } catch(e){
-        return vscode.window.showErrorMessage(e.message);
-      } 
-    });
+  let privateKey = await vscode.window.showInputBox({
+    prompt: 'Private Key used to sign the request (it will be kept in memory). If blank, the "signaturePrivateKey" configured option will be used.', 
+    value: suggestedPrivateKey 
+  });
+  if (typeof privateKey === 'undefined') {
+    return;
+  }
+
+  suggestedPrivateKey = privateKey;
+  privateKey = privateKey || settings.privateKey;
+
+  if (!privateKey) {
+    return vscode.window.showErrorMessage("You'll need to provide a private key or configure a default in samlExtension.privateKey");
+  }
+
+  let certificate = await vscode.window.showInputBox({
+    prompt: 'Public Key Certificate to include in the signature. If blank, the "signatureCertificate" configured option will be used.', 
+    value: suggestedCertificate
+  });
+  if (typeof certificate === 'undefined') {
+    return;
+  }
+  suggestedCertificate = certificate;
+
+  certificate = certificate || settings.publicKey;
+  if (!certificate) {
+    return vscode.window.showErrorMessage("You'll need to provide a certificate or configure a default in samlExtension.publicKey");
+  }
+
+  try{
+    setText(samlElement.signXml(privateKey, certificate));
+  } catch(e){
+    return vscode.window.showErrorMessage(e.message);
+  } 
 };
 
 export function verify(){
@@ -73,6 +98,9 @@ export function decrypt(){
 
    vscode.window.showInputBox({prompt: 'Provide Decryption Key'})
     .then(val => {
+      if (typeof val === "undefined") {
+        return;
+      }
       val = utils.formatCert(val || '');
       samlElement.decrypt(val, (err, dec) => {
         if (err) {

--- a/src/src/index.ts
+++ b/src/src/index.ts
@@ -150,7 +150,7 @@ function setText(txt){
 }
 
 function createSAMLElement(text):any{
-  var xml = new xmldom.DOMParser().parseFromString(text);
+  var xml = new xmldom.DOMParser().parseFromString(utils.normalizeLineEndings(text));
   var firstChild = xml.firstChild;
   // skip processing instructions
   while (firstChild && firstChild.nodeType !== ELEMENT_NODE) {

--- a/src/src/index.ts
+++ b/src/src/index.ts
@@ -114,6 +114,10 @@ export function decrypt(){
 
 export function getThumbprint(){
   var text = getText();
+  if (!text) {
+    return;
+  }
+  setText(utils.calculateThumbprint(text));
 };
 
 export function encode(){
@@ -148,6 +152,15 @@ export function urlDecode(){
 
 export function urlEncode(){
   setText(encodeURIComponent(getText()));
+}
+
+export function formatCertificate() {
+  var cert = getText();
+  if (!cert) {
+    return;
+  }
+
+  setText(utils.certToPEM(cert));
 }
 
 function getText(){

--- a/src/src/utils.ts
+++ b/src/src/utils.ts
@@ -55,3 +55,15 @@ export function certToPEM(cert) {
   cert = cert + "\n-----END CERTIFICATE-----\n";
   return cert;
 }
+
+export function normalizeLineEndings(xmlText) {
+  // normalize line endings
+  // this should be done once, before parsing the raw XML string
+  return xmlText.replace(/\r\n?/g, "\n");
+}
+
+export function encodeCarriageReturns(xmlText) {
+  // re-encode carriage returns that remain after line
+  // ending normalization.
+  return xmlText.replace(/\r/g, "&#13;");
+}

--- a/src/src/utils.ts
+++ b/src/src/utils.ts
@@ -9,7 +9,7 @@ export function removeHeaders(cert) {
   if (pem && pem.length > 0) {
     return pem[2].replace(/[\n|\r\n]/g, '');
   }
-  return null;
+  return cert;
 }
 
 export function formatCert(cert) {


### PR DESCRIPTION
## Different line endings handling

Properly handles different line endings used in the editor by:

- Normalizing to `/n` before processing the XML
This will ensure that signatures validate correctly even if the user is using CRLF encoding.

- Encoding back `/r` into character entities after signing or decrypting, to handle the case where an element has a CR character entity:

```
<someElement>
  A line&#13;
A second line
</someElement>
```

  The extension will now handle these cases gracefully and leave these entities in place when signing an XML element.

## A default private key can now be configured
You can use `samlExtension.privateKey` to store a default private key used for signing. 
The extension will ask for one and use the default if one is not provided. Also, the extension will now ask for a public key certificate to include in the signature, or use the configured `samlExtension.publicKey` if one is not provided.

## Two new handy commands

- "Format Certificate as PEM": normalizes a certificate base64 data by adding the standard header and footer, and using 64-char-long lines.
- "Calculate Certificate Thumbprint"

