### PR TITLE
Fix thumbprint calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "saml-extension",
       "version": "0.0.15",
       "dependencies": {
-        "thumbprint": "0.0.1",
         "xml-crypto": "^1.5.3",
         "xml-encryption": "^0.10.0",
         "xmldom": "^0.6.0",
@@ -1290,10 +1289,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/thumbprint": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "dev": true,
@@ -2332,9 +2327,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "thumbprint": {
-      "version": "0.0.1"
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "thumbprint": "0.0.1",
     "xml-crypto": "^1.5.3",
     "xml-encryption": "^0.10.0",
     "xmldom": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saml-extension",
   "displayName": "SAML Extension",
   "description": "SAML Extension",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "publisher": "mcastany",
   "engines": {
     "vscode": "^1.70.0"

--- a/src/src/elements/BaseElement.ts
+++ b/src/src/elements/BaseElement.ts
@@ -1,3 +1,5 @@
+import { calculateThumbprint } from "../utils";
+
 const vscode        = require('vscode');
 const xmlCrypto     = require('xml-crypto');
 const xpath         = require('xpath');
@@ -192,9 +194,10 @@ export default class BaseElement{
     for(const certificate of certificates) {
       const certificateText = xpath.select("text()", certificate);
       if (certificateText && certificateText.length === 1) {
+        const pem = utils.certToPEM(certificateText[0].toString().trim());
         results.push({
-          label: `${index} - ${BaseElement.getCertificateLabel(certificate)}`,
-          text: utils.certToPEM(certificateText[0].toString().trim())
+          label: `${index} - ${BaseElement.getCertificateLabel(certificate)} - ${calculateThumbprint(pem)}`,
+          text: pem
         });
         index++;
       }

--- a/src/src/utils.ts
+++ b/src/src/utils.ts
@@ -1,4 +1,4 @@
-const thumbprint    = require('thumbprint');
+const crypto        = require('crypto');
 const xmldom        = require('xmldom');
 const DOMParser     = xmldom.DOMParser;
 const whitespace    = /^\s+$/;
@@ -22,8 +22,11 @@ export function formatCert(cert) {
 }
 
 export function calculateThumbprint(pem) {
-  var cert = removeHeaders(pem);
-  return thumbprint.calculate(cert).toUpperCase();
+  const cert = removeHeaders(pem);
+  const shasum = crypto.createHash('sha1');
+  const der = Buffer.from(cert, 'base64').toString('binary')
+  shasum.update(der, 'binary');
+  return shasum.digest('hex');
 }
 
 export function removeEmptyNodes(node) {


### PR DESCRIPTION
This PR fixes the calculation of certificate thumbprints. It also adds the thumbprint next to the certificate path when showing a list of certificates for the user to choose from.
<img width="727" alt="image" src="https://github.com/mcastany/vscode-saml-extension/assets/5222181/0d2f619f-740b-4e59-be79-3a1e48e2ec67">
